### PR TITLE
Fix: Update Python versions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.6
+          python-version: '3.11'
       - name: Black
-        uses: lgeiger/black-action@master
+        uses: psf/black-action@stable
         with:
           args: ". --check"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,16 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.6
+          python-version: '3.11'
       - name: Install dependencies
         run: pip install pipenv && pipenv install && pipenv run pip install pytest pytest-cov
       - name: Execute unit tests
         run: pipenv run pytest --cov=project/ --cov-report term-missing project/ tests/ -r s
       - name: Coveralls
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.COVERALLS_TOKEN }}
 
@@ -25,9 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build and push image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v5
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.6
+          python-version: '3.11'
       - name: Install dependencies
         run: pip install bandit
       - name: Execute bandit
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.6
+          python-version: '3.11'
       - name: Install dependencies
         run: pip install safety
       - name: Execute safety


### PR DESCRIPTION
- Updated Python version from 3.6 to 3.11 in all workflows. Python 3.6 is deprecated and no longer available in the GitHub Actions cache.
- Updated `actions/checkout` from `v2` to `v4`.
- Updated `actions/setup-python` from `v2` to `v5`.
- Replaced `lgeiger/black-action@master` with `psf/black-action@stable` in `lint.yml` due to the former being outdated.
- Replaced `AndreMiras/coveralls-python-action@develop` with `coverallsapp/github-action@v2` in `main.yml` due to the former being outdated.
- Updated `docker/build-push-action` from `v1` to `v5` in `main.yml`.

These changes address the issue of workflows failing due to the use of an unsupported Python version and ensure the use of up-to-date actions for better security and functionality.